### PR TITLE
feat: Add base of serialization

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.jetbrains:annotations:24.0.0")
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/common/src/main/java/sd/cloudcomputing/common/JobRequest.java
+++ b/common/src/main/java/sd/cloudcomputing/common/JobRequest.java
@@ -1,5 +1,10 @@
 package sd.cloudcomputing.common;
 
+import sd.cloudcomputing.common.serialization.Frost;
+import sd.cloudcomputing.common.serialization.Serialize;
+import sd.cloudcomputing.common.serialization.SerializeInput;
+import sd.cloudcomputing.common.serialization.SerializeOutput;
+
 public class JobRequest {
 
     private final byte[] data;
@@ -10,5 +15,20 @@ public class JobRequest {
 
     public byte[] getData() {
         return data;
+    }
+
+    public static class Serialization implements Serialize<JobRequest> {
+
+        @Override
+        public JobRequest deserialize(SerializeInput input, Frost frost) {
+            byte[] bytes = frost.readBytes(input);
+
+            return new JobRequest(bytes);
+        }
+
+        @Override
+        public void serialize(JobRequest object, SerializeOutput output, Frost frost) {
+            frost.writeBytes(object.getData(), output);
+        }
     }
 }

--- a/common/src/main/java/sd/cloudcomputing/common/serialization/Frost.java
+++ b/common/src/main/java/sd/cloudcomputing/common/serialization/Frost.java
@@ -1,0 +1,127 @@
+package sd.cloudcomputing.common.serialization;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Frost {
+
+    private final Map<Class<?>, Serialize<?>> customSerializers = new HashMap<>();
+
+    public void writeInt(int value, SerializeOutput output) {
+        try {
+            output.writeInt(value);
+        } catch (IOException e) {
+            throw new SerializationException("writeInt", e);
+        }
+    }
+
+    public void writeLong(long value, SerializeOutput output) {
+        try {
+            output.writeLong(value);
+        } catch (IOException e) {
+            throw new SerializationException("writeLong", e);
+        }
+    }
+
+    public void writeString(@NotNull String value, SerializeOutput output) {
+        try {
+            output.writeString(value);
+        } catch (IOException e) {
+            throw new SerializationException("writeString", e);
+        }
+    }
+
+    public void writeBoolean(boolean value, SerializeOutput output) {
+        try {
+            output.writeBoolean(value);
+        } catch (IOException e) {
+            throw new SerializationException("writeBoolean", e);
+        }
+    }
+
+    public <T> void writeSerializable(@NotNull T value, Class<T> clazz, SerializeOutput output) {
+        Serialize<T> serializer = getSerializer(clazz);
+        if (serializer == null) {
+            throw new IllegalArgumentException("No serializer has been registered for class " + clazz.getName());
+        }
+        serializer.serialize(value, output, this);
+    }
+
+    public void writeBytes(byte @NotNull [] value, SerializeOutput output) {
+        try {
+            output.writeBytes(value);
+        } catch (IOException e) {
+            throw new SerializationException("writeBytes", e);
+        }
+    }
+
+    public void flush(SerializeOutput output) {
+        try {
+            output.flush();
+        } catch (IOException e) {
+            throw new SerializationException("flush", e);
+        }
+    }
+
+    public int readInt(SerializeInput input) {
+        try {
+            return input.readInt();
+        } catch (IOException e) {
+            throw new SerializationException("readInt", e);
+        }
+    }
+
+    public long readLong(SerializeInput input) {
+        try {
+            return input.readLong();
+        } catch (IOException e) {
+            throw new SerializationException("readLong", e);
+        }
+    }
+
+    public String readString(SerializeInput input) {
+        try {
+            return input.readString();
+        } catch (IOException e) {
+            throw new SerializationException("readString", e);
+        }
+    }
+
+    public boolean readBoolean(SerializeInput input) {
+        try {
+            return input.readBoolean();
+        } catch (IOException e) {
+            throw new SerializationException("readBoolean", e);
+        }
+    }
+
+    public <T> T readSerializable(Class<T> clazz, SerializeInput input) {
+        Serialize<T> serializer = getSerializer(clazz);
+        if (serializer == null) {
+            throw new IllegalArgumentException("No serializer has been registered for class " + clazz.getName());
+        }
+        return serializer.deserialize(input, this);
+    }
+
+    public byte @NotNull [] readBytes(SerializeInput input) {
+        try {
+            return input.readBytes();
+        } catch (IOException e) {
+            throw new SerializationException("readBytes", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> @Nullable Serialize<T> getSerializer(Class<T> clazz) {
+        return (Serialize<T>) customSerializers.get(clazz);
+    }
+
+    public <T> void registerSerializer(Class<T> clazz, Serialize<T> serializer) {
+        customSerializers.put(clazz, serializer);
+    }
+
+}

--- a/common/src/main/java/sd/cloudcomputing/common/serialization/SerializationException.java
+++ b/common/src/main/java/sd/cloudcomputing/common/serialization/SerializationException.java
@@ -1,0 +1,8 @@
+package sd.cloudcomputing.common.serialization;
+
+public class SerializationException extends RuntimeException {
+
+    public SerializationException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/common/src/main/java/sd/cloudcomputing/common/serialization/Serialize.java
+++ b/common/src/main/java/sd/cloudcomputing/common/serialization/Serialize.java
@@ -1,0 +1,9 @@
+package sd.cloudcomputing.common.serialization;
+
+public interface Serialize<T> {
+
+    T deserialize(SerializeInput input, Frost frost);
+
+    void serialize(T object, SerializeOutput output, Frost frost);
+
+}

--- a/common/src/main/java/sd/cloudcomputing/common/serialization/SerializeInput.java
+++ b/common/src/main/java/sd/cloudcomputing/common/serialization/SerializeInput.java
@@ -1,0 +1,36 @@
+package sd.cloudcomputing.common.serialization;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+public class SerializeInput {
+
+    private final DataInputStream stream;
+
+    public SerializeInput(DataInputStream stream) {
+        this.stream = stream;
+    }
+
+    public int readInt() throws IOException {
+        return stream.readInt();
+    }
+
+    public long readLong() throws IOException {
+        return stream.readLong();
+    }
+
+    public String readString() throws IOException {
+        return stream.readUTF();
+    }
+
+    public byte[] readBytes() throws IOException {
+        int length = stream.readInt();
+        byte[] bytes = new byte[length];
+        stream.readFully(bytes);
+        return bytes;
+    }
+
+    public boolean readBoolean() throws IOException {
+        return stream.readBoolean();
+    }
+}

--- a/common/src/main/java/sd/cloudcomputing/common/serialization/SerializeOutput.java
+++ b/common/src/main/java/sd/cloudcomputing/common/serialization/SerializeOutput.java
@@ -1,0 +1,40 @@
+package sd.cloudcomputing.common.serialization;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class SerializeOutput {
+
+    private final DataOutputStream stream;
+
+    public SerializeOutput(DataOutputStream stream) {
+        this.stream = stream;
+    }
+
+    public void writeInt(int value) throws IOException {
+        stream.writeInt(value);
+    }
+
+    public void writeLong(long value) throws IOException {
+        stream.writeLong(value);
+    }
+
+    public void writeString(@NotNull String value) throws IOException {
+        stream.writeUTF(value);
+    }
+
+    public void writeBoolean(boolean value) throws IOException {
+        stream.writeBoolean(value);
+    }
+
+    public void writeBytes(byte @NotNull [] value) throws IOException {
+        stream.writeInt(value.length);
+        stream.write(value);
+    }
+
+    public void flush() throws IOException {
+        stream.flush();
+    }
+}

--- a/common/src/test/java/sd/cloudcomputing/common/JobRequestSerializationTest.java
+++ b/common/src/test/java/sd/cloudcomputing/common/JobRequestSerializationTest.java
@@ -1,0 +1,47 @@
+package sd.cloudcomputing.common;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import sd.cloudcomputing.common.serialization.Frost;
+import sd.cloudcomputing.common.serialization.SerializeInput;
+import sd.cloudcomputing.common.serialization.SerializeOutput;
+
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JobRequestSerializationTest {
+
+    static final Frost frost = new Frost();
+
+    @BeforeAll
+    static void setup() {
+        frost.registerSerializer(JobRequest.class, new JobRequest.Serialization());
+    }
+
+    @Test
+    void testSerialization() {
+        JobRequest jobRequest = new JobRequest(new byte[]{1, 2, 3, 4, 5});
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializeOutput output = new SerializeOutput(new DataOutputStream(out));
+
+        frost.writeSerializable(jobRequest, JobRequest.class, output);
+        frost.flush(output);
+
+        byte[] serialized = out.toByteArray();
+
+        ByteArrayInputStream in = new ByteArrayInputStream(serialized);
+        SerializeInput input = new SerializeInput(new DataInputStream(in));
+
+        JobRequest deserialized = frost.readSerializable(JobRequest.class, input);
+
+        assertEquals(5, deserialized.getData().length);
+        assertEquals(1, deserialized.getData()[0]);
+        assertEquals(2, deserialized.getData()[1]);
+        assertEquals(3, deserialized.getData()[2]);
+        assertEquals(4, deserialized.getData()[3]);
+        assertEquals(5, deserialized.getData()[4]);
+    }
+
+}

--- a/common/src/test/java/sd/cloudcomputing/common/JobResultSerializationTest.java
+++ b/common/src/test/java/sd/cloudcomputing/common/JobResultSerializationTest.java
@@ -1,0 +1,72 @@
+package sd.cloudcomputing.common;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import sd.cloudcomputing.common.serialization.Frost;
+import sd.cloudcomputing.common.serialization.SerializeInput;
+import sd.cloudcomputing.common.serialization.SerializeOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JobResultSerializationTest {
+
+    static final Frost frost = new Frost();
+
+    @BeforeAll
+    static void setup() {
+        frost.registerSerializer(JobResult.class, new JobResult.Serialization());
+    }
+
+    @Test
+    void testSerializationResultSuccess() {
+        JobResult jobResult = JobResult.success(new byte[]{1, 2, 3, 4, 5});
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializeOutput output = new SerializeOutput(new DataOutputStream(out));
+
+        frost.writeSerializable(jobResult, JobResult.class, output);
+        frost.flush(output);
+
+        byte[] serialized = out.toByteArray();
+
+        ByteArrayInputStream in = new ByteArrayInputStream(serialized);
+        SerializeInput input = new SerializeInput(new DataInputStream(in));
+
+        JobResult deserialized = frost.readSerializable(JobResult.class, input);
+
+        assertEquals(JobResult.ResultType.SUCCESS, deserialized.getResultType());
+        assertEquals(5, deserialized.getData().length);
+        assertEquals(1, deserialized.getData()[0]);
+        assertEquals(2, deserialized.getData()[1]);
+        assertEquals(3, deserialized.getData()[2]);
+        assertEquals(4, deserialized.getData()[3]);
+        assertEquals(5, deserialized.getData()[4]);
+    }
+
+    @Test
+    void testSerializationResultFailure() {
+        JobResult jobResult = JobResult.failure(1, "error");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializeOutput output = new SerializeOutput(new DataOutputStream(out));
+
+        frost.writeSerializable(jobResult, JobResult.class, output);
+        frost.flush(output);
+
+        byte[] serialized = out.toByteArray();
+
+        ByteArrayInputStream in = new ByteArrayInputStream(serialized);
+        SerializeInput input = new SerializeInput(new DataInputStream(in));
+
+        JobResult deserialized = frost.readSerializable(JobResult.class, input);
+
+        assertEquals(JobResult.ResultType.FAILURE, deserialized.getResultType());
+        assertEquals(1, deserialized.getErrorCode());
+        assertEquals("error", deserialized.getErrorMessage());
+    }
+}


### PR DESCRIPTION
API de serialização inspirada no *Kryo* (o nosso chama-se *Frost* porque é o nome abaixo de crio-...).

Ver exemplos de serialização implementados no [JobRequest.java](https://github.com/chicoferreira/sd-cloud-computing/blob/cmf/serialization/common/src/main/java/sd/cloudcomputing/common/JobRequest.java) e no [JobResult.java](https://github.com/chicoferreira/sd-cloud-computing/blob/cmf/serialization/common/src/main/java/sd/cloudcomputing/common/JobResult.java). 

Ver utilização de api nos testes: [JobRequestSerializationTest](https://github.com/chicoferreira/sd-cloud-computing/blob/cmf/serialization/common/src/test/java/sd/cloudcomputing/common/JobRequestSerializationTest.java) [JobResultSerializationTest](https://github.com/chicoferreira/sd-cloud-computing/blob/cmf/serialization/common/src/test/java/sd/cloudcomputing/common/JobResultSerializationTest.java).